### PR TITLE
Flatten paths and trim filenames

### DIFF
--- a/src/main/java/re/imc/geysermodelenginepackgenerator/PackGenerator.java
+++ b/src/main/java/re/imc/geysermodelenginepackgenerator/PackGenerator.java
@@ -271,8 +271,8 @@ public class PackGenerator {
             if (geo != null) {
                 entry.getValue().addHeadBind(geo);
             }
-            Path path = animationsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".animation.json");
-            Path pathController = animationControllersFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".animation_controllers.json");
+            Path path = animationsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
+            Path pathController = animationControllersFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
 
             pathController.toFile().getParentFile().mkdirs();
             path.toFile().getParentFile().mkdirs();
@@ -294,7 +294,7 @@ public class PackGenerator {
 
         for (Map.Entry<String, Geometry> entry : geometryMap.entrySet()) {
             entry.getValue().modify();
-            Path path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".geo.json");
+            Path path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
             path.toFile().getParentFile().mkdirs();
             String id = entry.getValue().getGeometryId();
 
@@ -309,7 +309,7 @@ public class PackGenerator {
                         String suffix = size[0] + "_" + size[1];
                         entry.getValue().setTextureWidth(size[0]);
                         entry.getValue().setTextureHeight(size[1]);
-                        path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + "_" + suffix + ".geo.json");
+                        path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + "_" + suffix + ".json");
 
                         entry.getValue().setId(id + "_" + suffix);
 
@@ -361,7 +361,7 @@ public class PackGenerator {
             Entity entity = entry.getValue();
             entity.modify();
 
-            Path entityPath = entityFolder.toPath().resolve(entity.getPath() + entry.getKey() + ".entity.json");
+            Path entityPath = entityFolder.toPath().resolve(entity.getPath() + entry.getKey() + ".json");
             entityPath.toFile().getParentFile().mkdirs();
             if (entityPath.toFile().exists()) {
                 continue;
@@ -378,7 +378,7 @@ public class PackGenerator {
             if (!geometryMap.containsKey(id)) continue;
             RenderController controller = new RenderController(id, geometryMap.get(id).getBones(), entity);
             entity.setRenderController(controller);
-            Path renderPath = new File(renderControllersFolder, "controller.render." + id + ".json").toPath();
+            Path renderPath = new File(renderControllersFolder, id + ".json").toPath();
             if (renderPath.toFile().exists()) {
                 continue;
             }

--- a/src/main/java/re/imc/geysermodelenginepackgenerator/PackGenerator.java
+++ b/src/main/java/re/imc/geysermodelenginepackgenerator/PackGenerator.java
@@ -271,8 +271,8 @@ public class PackGenerator {
             if (geo != null) {
                 entry.getValue().addHeadBind(geo);
             }
-            Path path = animationsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
-            Path pathController = animationControllersFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
+            Path path = animationsFolder.toPath().resolve(entry.getKey() + ".json");
+            Path pathController = animationControllersFolder.toPath().resolve(entry.getKey() + ".json");
 
             pathController.toFile().getParentFile().mkdirs();
             path.toFile().getParentFile().mkdirs();
@@ -294,7 +294,7 @@ public class PackGenerator {
 
         for (Map.Entry<String, Geometry> entry : geometryMap.entrySet()) {
             entry.getValue().modify();
-            Path path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + ".json");
+            Path path = modelsFolder.toPath().resolve(entry.getKey() + ".json");
             path.toFile().getParentFile().mkdirs();
             String id = entry.getValue().getGeometryId();
 
@@ -309,7 +309,7 @@ public class PackGenerator {
                         String suffix = size[0] + "_" + size[1];
                         entry.getValue().setTextureWidth(size[0]);
                         entry.getValue().setTextureHeight(size[1]);
-                        path = modelsFolder.toPath().resolve(entry.getValue().getPath() + entry.getKey() + "_" + suffix + ".json");
+                        path = modelsFolder.toPath().resolve(entry.getKey() + "_" + suffix + ".json");
 
                         entry.getValue().setId(id + "_" + suffix);
 
@@ -341,7 +341,7 @@ public class PackGenerator {
         for (Map.Entry<String, Map<String, Texture>> textures : textureMap.entrySet()) {
 
             for (Map.Entry<String, Texture> entry : textures.getValue().entrySet()) {
-                Path path = texturesFolder.toPath().resolve(entry.getValue().getPath() + textures.getKey() + "/" + entry.getKey() + ".png");
+                Path path = texturesFolder.toPath().resolve(entry.getKey() + ".png");
                 path.toFile().getParentFile().mkdirs();
 
                 if (path.toFile().exists()) {
@@ -361,7 +361,7 @@ public class PackGenerator {
             Entity entity = entry.getValue();
             entity.modify();
 
-            Path entityPath = entityFolder.toPath().resolve(entity.getPath() + entry.getKey() + ".json");
+            Path entityPath = entityFolder.toPath().resolve(entry.getKey() + ".json");
             entityPath.toFile().getParentFile().mkdirs();
             if (entityPath.toFile().exists()) {
                 continue;
@@ -378,7 +378,7 @@ public class PackGenerator {
             if (!geometryMap.containsKey(id)) continue;
             RenderController controller = new RenderController(id, geometryMap.get(id).getBones(), entity);
             entity.setRenderController(controller);
-            Path renderPath = new File(renderControllersFolder, id + ".json").toPath();
+            Path renderPath = new File(renderControllersFolder, "meg_" + id + ".json").toPath();
             if (renderPath.toFile().exists()) {
                 continue;
             }

--- a/src/main/java/re/imc/geysermodelenginepackgenerator/generator/Entity.java
+++ b/src/main/java/re/imc/geysermodelenginepackgenerator/generator/Entity.java
@@ -72,7 +72,7 @@ public class Entity {
 
         json = new JsonParser().parse(TEMPLATE.replace("%entity_id%", modelId)
                 .replace("%geometry%", "geometry.meg_" + modelId)
-                .replace("%texture%", "textures/entity/" + path + modelId)
+                .replace("%texture%", "textures/entity/" + modelId)
                 .replace("%look_at_target%",  modelConfig.isEnableHeadRotation() ? "animation." + modelId + ".look_at_target" : "animation.none")
                 .replace("%material%", modelConfig.getMaterial())).getAsJsonObject();
 
@@ -88,8 +88,8 @@ public class Entity {
         materials.forEach(jsonMaterials::addProperty);
 
         if (modelConfig.getPerTextureUvSize().isEmpty()) {
-            jsonGeometry.addProperty("default", "geometry.meg_" + modelId);
-            jsonTextures.addProperty("default", "textures/entity/" + path + modelId + "/" + textureMap.keySet().stream().findFirst().orElse("def"));
+            jsonGeometry.addProperty(modelId, "geometry.meg_" + modelId);
+            jsonTextures.addProperty("default", "textures/entity/" + modelId);
         }
 
         for (String name : textureMap.keySet()) {
@@ -100,11 +100,12 @@ public class Entity {
                 Integer[] size = modelConfig.getPerTextureUvSize().getOrDefault(name, new Integer[]{16, 16});
                 String suffix = size[0] + "_" + size[1];
 
-                jsonGeometry.addProperty("t_" + suffix, "geometry.meg_" + modelId + "_" + suffix);
-                jsonTextures.addProperty(name, "textures/entity/" + path + modelId + "/" + name);
+                jsonGeometry.addProperty(modelId + "_" + suffix, "geometry.meg_" + modelId + "_" + suffix);
+                jsonTextures.addProperty(name, "textures/entity/" + name);
 
             }
-            jsonRenderControllers.add("controller.render." + modelId + "_" + name);
+            String controllerName = name.equals(modelId) ? "controller.render.meg_" + modelId : "controller.render.meg_" + modelId + "_" + name;
+            jsonRenderControllers.add(controllerName);
 
         }
 

--- a/src/main/java/re/imc/geysermodelenginepackgenerator/generator/RenderController.java
+++ b/src/main/java/re/imc/geysermodelenginepackgenerator/generator/RenderController.java
@@ -72,7 +72,9 @@ public class RenderController {
                 controller.add("uv_anim", uvAnim);
                 JsonArray offset = new JsonArray();
                 offset.add(0.0);
-                offset.add("math.mod(math.floor(q.life_time * " + anim.fps + ")," + anim.frames + ") / " + anim.frames);
+                // Cap fps at reasonable value (7.0 is standard for Bedrock animations)
+                double animFps = anim.fps > 60 ? 7.0 : anim.fps;
+                offset.add("math.mod(math.floor(q.life_time * " + animFps + ")," + anim.frames + ") / " + anim.frames);
                 uvAnim.add("offset", offset);
                 JsonArray scale = new JsonArray();
                 scale.add(1.0);

--- a/src/main/java/re/imc/geysermodelenginepackgenerator/generator/RenderController.java
+++ b/src/main/java/re/imc/geysermodelenginepackgenerator/generator/RenderController.java
@@ -49,14 +49,15 @@ public class RenderController {
 
             JsonObject controller = new JsonObject();
 
-            renderControllers.add("controller.render." + modelId + "_" + key, controller);
+            String controllerName = key.equals(modelId) ? "controller.render.meg_" + modelId : "controller.render.meg_" + modelId + "_" + key;
+            renderControllers.add(controllerName, controller);
 
             if (!entity.getModelConfig().getPerTextureUvSize().isEmpty()) {
                 Integer[] size = entity.getModelConfig().getPerTextureUvSize().getOrDefault(key, new Integer[]{16, 16});
-                String suffix = "t_" + size[0] + "_" + size[1];
-                controller.addProperty("geometry", "Geometry." + suffix);
+                String suffix = size[0] + "_" + size[1];
+                controller.addProperty("geometry", "Geometry." + modelId + "_" + suffix);
             } else {
-                controller.addProperty("geometry", "Geometry.default");
+                controller.addProperty("geometry", "Geometry." + modelId);
             }
             JsonArray materials = new JsonArray();
             String material = entity.getModelConfig().getTextureMaterials().get(key);


### PR DESCRIPTION
Some platforms have an 80 character path length limit, and longer paths prevent the pack from loading. To fix this:

**Flattened paths**: files go directly into folders, no more nested subdirectories. Example: `entity/pets/baby_breeze_pet.entity.json` becomes `entity/baby_breeze_pet.json`. Minecraft Java of ModelEngine also does it this way. 

**Shorter filenames**: dropped verbose suffixes like `.animation.json`, `.geo.json`, `.entity.json`, `.animation_controllers.json`. Everything is just `.json` now.

**Namespaced render controllers**: added `meg_` prefix to avoid vanilla conflicts. For example, `controller.render.happy_ghast` becomes `controller.render.meg_happy_ghast`, and the file is now `meg_happy_ghast.json` instead of `controller.render.happy_ghast.json`

**Better geometry names**: model-specific instead of generic. `Geometry.default` becomes `Geometry.modelId`, `Geometry.t_64_64` becomes `Geometry.modelId_64_64`

**Fixed animated texture fps**: values above 60 now cap to 7.0 (standard Bedrock speed). Fixes broken configs that had fps set to 1000.